### PR TITLE
fix(FarmService): prefer `trigger_error` to `exit` if config file is …

### DIFF
--- a/services/FarmService.php
+++ b/services/FarmService.php
@@ -134,13 +134,14 @@ class FarmService
             $this->wiki->config['yeswiki-farm-models'][] = 'default-content';
         } else {
             // verifier l'existence des parametres des fichiers sql
-            foreach ($this->wiki->config['yeswiki-farm-models'] as $folder) {
+            foreach ($this->wiki->config['yeswiki-farm-models'] as $key => $folder) {
                 if ($folder != 'default-content') {
                     if (!is_dir('custom/wiki-models/'.$folder)) {
-                        exit('<div class="alert alert-danger">le dossier "custom/wiki-models/'.$folder.'" ne semble pas exister.</div>');
-                    }
-                    if (!is_file('custom/wiki-models/'.$folder.'/default-content.sql')) {
-                        exit('<div class="alert alert-danger">Le fichier sql "custom/wiki-models/'.$folder.'/default-content.sql" n\'a pas été trouvé.</div>');
+                        unset($this->wiki->config['yeswiki-farm-models'][$key]);
+                        trigger_error('<div class="alert alert-danger">le dossier "custom/wiki-models/'.$folder.'" ne semble pas exister.</div>');
+                    } elseif (!is_file('custom/wiki-models/'.$folder.'/default-content.sql')) {
+                        unset($this->wiki->config['yeswiki-farm-models'][$key]);
+                        trigger_error('<div class="alert alert-danger">Le fichier sql "custom/wiki-models/'.$folder.'/default-content.sql" n\'a pas été trouvé.</div>');
                     }
                 }
             }


### PR DESCRIPTION
…not up to date with custom/wiki-models folder

Pour cette mini-modification je préfère passer par une PR car tu avais peut-être une raison particulière de faire un `exit()`.
En tout cas, je propose de vider le tableau `$wiki->config['yeswiki-farm-models']` des valeurs non trouvées dans le dossier `custom/wiki-models` et de juste lever une erreur php par `trigger_error` afin de ne as faire planter tout le site et d'avoir ainsi la possibilitié de supprimer le site manquant à la main avec `{{generatemodel}}`sans passer par ftp