### PR TITLE
fix(UpdateHandler__): prepare to next doryphore release

### DIFF
--- a/handlers/UpdateHandler__.php
+++ b/handlers/UpdateHandler__.php
@@ -15,195 +15,87 @@
 namespace YesWiki\Ferme;
 
 use Exception;
-use YesWiki\Bazar\Service\EntryManager;
-use YesWiki\Bazar\Service\FormManager;
-use YesWiki\Core\Service\AclService;
-use YesWiki\Core\Service\DbService;
 use YesWiki\Core\Service\PageManager;
-use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\YesWikiHandler;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+use YesWiki\Security\Controller\SecurityController;
 
 class UpdateHandler__ extends YesWikiHandler
 {
-    private const PATHS = [
-        'lists' => [
-            'ListeOuiNon' => 'tools/ferme/setup/lists/ListeOuiNon.json',
-        ],
-        'forms' => [
-            'Farm description' => 'tools/ferme/setup/forms/Form - Farm.json',
-            'Farm template' => 'tools/ferme/setup/forms/Form - Farm - template.txt',
-        ],
-        'pages' => [
-            'AdminWikis' => 'tools/ferme/setup/pages/AdminWikis.txt',
-            'AjouterWiki' => 'tools/ferme/setup/pages/AjouterWiki.txt',
-            // 'ContactWikis' => 'tools/ferme/setup/pages/ContactWikis.txt',
-            'ModelesWiki' => 'tools/ferme/setup/pages/ModelesWiki.txt',
-            'PageRapideHaut' => 'tools/ferme/setup/pages/PageRapideHaut.txt',
-        ],
-    ];
-
     public function run()
     {
-        $output = '';
-        if ($this->wiki->UserIsAdmin()) {
-            $pageManager = $this->getService(PageManager::class);
-            $tripleStore = $this->getService(TripleStore::class);
-            $dbService = $this->getService(DbService::class);
-            $entryManager = $this->getService(EntryManager::class);
-
-            $output .= '<strong>Extension Ferme</strong><br/>';
-        
-            // Structure de répertoire désirée
-            $customWikiModelDir = 'custom/wiki-models/';
-            if (!is_dir($customWikiModelDir)) {
-                if (!mkdir($customWikiModelDir, 0777, true)) {
-                    throw new Exception('Folder creation failed...');
-                } else {
-                    $output .= "ℹ️ Creating the folder <em>$customWikiModelDir</em> for the wiki models<br/>✅Done !<br />";
-                }
-            } else {
-                $output .= "✅ The folder <em>$customWikiModelDir</em> for the wiki models exists.<br />";
-            }
-        
-        
-            // if the OuiNon Lms list doesn't exist, create it
-            if (!$pageManager->getOne('ListeOuiNon')) {
-                $output .= 'ℹ️ Adding the <em>Oui Non</em> list<br />';
-                // save the page with the list value
-                $pageManager->save('ListeOuiNon', $this->loadFileContent('lists', 'ListeOuiNon'));
-                // in case, there is already some triples for 'ListOuinonLms', delete them
-                $tripleStore->delete('ListeOuiNon', 'http://outils-reseaux.org/_vocabulary/type', null);
-                // create the triple to specify this page is a list
-                $tripleStore->create('ListeOuiNon', 'http://outils-reseaux.org/_vocabulary/type', 'liste', '', '');
-                $output .= '✅ Done !<br />';
-            } else {
-                $output .= '✅ The <em>Oui Non</em> list already exists.<br />';
-            }
-        
-            // test if the FARM form exists, if not, install it
-            $formDescription = json_decode($this->loadFileContent('forms', 'Farm description'), true);
-            $formTemplate = $this->loadFileContent('forms', 'Farm template');
-            $formTemplate = str_replace('{UtilisationDonnees}', $this->wiki->Href('', 'UtilisationDonnees'), $formTemplate);
-            $formTemplate = str_replace('{Contact}', $this->wiki->Href('', 'Contact'), $formTemplate);
-            if (empty($formTemplate)) {
-                $output .= "! not possible to add <em>famr</em> form !<br />";
-            } else {
-                $output = $this->checkAndAddForm(
-                    $output,
-                    $this->params->get('bazar_farm_id'),
-                    $formDescription["FARM_FORM_NOM"],
-                    $formDescription["FARM_FORM_DESCRIPTION"],
-                    $formTemplate
-                );
-            }
-        
-            if (empty($pageManager->getOne('AdminWikis'))) {
-                $output = $this->updatePageRapideHaut($output);
-            }
-            $output = $this->updatePage('AdminWikis', $output);
-            $output = $this->updatePage('AjouterWiki', $output, ['{FarmFormId}' => $this->params->get('bazar_farm_id')]);
-            // $output = $this->updatePage('ContactWikis', $output);
-            $output = $this->updatePage('ModelesWiki', $output);
-        
-            // remove bf_dossier fields
-            if (method_exists(EntryManager::class, 'removeAttributes')) {
-                if ($entryManager->removeAttributes([], ['bf_dossier-wiki_wikiname','bf_dossier-wiki_email','bf_dossier-wiki_password'], true)) {
-                    $output .= "ℹ️ Removing bf_dossier fields from bazar entries in {$dbService->prefixTable('pages')} table.<br />";
-                    $output .= '✅ Done !<br />';
-                } else {
-                    $output .= "✅ The table {$dbService->prefixTable('pages')} is already free of bf_dossier fields in bazar entries !<br />";
-                }
-            } else {
-                $output .= "! Not possible to remove bf_dossier fields from bazar entries in {$dbService->prefixTable('pages')} table.<br />";
-            }
-            
-            $output .= '<hr />';
+        if ($this->getService(SecurityController::class)->isWikiHibernated()) {
+            throw new Exception(_t('WIKI_IN_HIBERNATION'));
+        };
+        if (!$this->wiki->UserIsAdmin()) {
+            return null;
         }
-        
-        // add the content before footer
-        $this->output = str_replace(
-            '<!-- end handler /update -->',
-            $output.'<!-- end handler /update -->',
-            $this->output
-        );
-    }
 
-    private function checkAndAddForm($output, $formId, $formName, $formDescription, $formTemplate)
-    {
-        $dbService = $this->getService(DbService::class);
-        $formManager = $this->getService(FormManager::class);
-
-        // test if the FARM form exists, if not, install it
-        $form = $formManager->getOne($formId);
-        if (empty($form)) {
-            $output .= "ℹ️ Adding <em>{$formName}</em> form into <em>{$dbService->prefixTable('nature')}</em> table.<br />";
-
-            $formManager->create([
-                'bn_id_nature' => $formId,
-                'bn_label_nature' => $formName,
-                'bn_template' => $formTemplate,
-                'bn_description' => $formDescription,
-                'bn_sem_context' => $formDescription,
-                'bn_sem_type' => '',
-                'bn_sem_use_template' => '1',
-                'bn_condition' => '',
-            ]);
-
-            $output .= '✅ Done !<br />';
-        } else {
-            $output .= "✅ The <em>{$formName}</em> form already exists in the <em>{$dbService->prefixTable('nature')}</em> table.<br />";
+        $version = $this->params->get('yeswiki_version');
+        if (!is_string($version)) {
+            $version = '';
         }
-        return $output;
-    }
-
-    private function loadFileContent(string $type, string $name):string
-    {
-        if (!isset(self::PATHS[$type]) || !isset(self::PATHS[$type][$name])) {
-            return '';
+        $release = $this->params->get('yeswiki_release');
+        if (!is_string($release)) {
+            $release = '';
         }
-        $path = self::PATHS[$type][$name];
-        return file_get_contents($path);
-    }
+        $matches = [];
+        if (
+            $version  !== 'doryphore'
+            || !preg_match("/^(\d+)\.(\d+)\.(\d+)\$/", $release, $matches)
+            || intval($matches[1]) > 4
+            || (
+                intval($matches[1]) === 4
+                && (
+                    intval($matches[2]) > 4
+                    || (
+                        intval($matches[2]) === 4
+                        && intval($matches[3]) > 4
+                    )
+                )
+            )
+        ) {
+            return null;
+        }
 
-    private function updatePage(string $pageName, string $output, array $replacements = []):string
-    {
-        $aclService = $this->getService(AclService::class);
         $pageManager = $this->getService(PageManager::class);
-        // if the page doesn't exist, create it with a default version
-        if (!$pageManager->getOne($pageName)) {
-            $output .= "ℹ️ Adding the <em>$pageName</em> page<br />";
-            $content = $this->loadFileContent('pages', $pageName);
-            if (!empty($replacements)) {
-                $content = str_replace(array_keys($replacements), array_values($replacements), $content);
-            }
-            $aclService->delete($pageName); // to clear acl cache
-            $aclService->save($pageName, 'read', '@admins');
-            $aclService->save($pageName, 'write', '@admins');
-            $pageManager->save($pageName, $content, "", true);
-            $output .= '✅ Done !<br />';
-        } else {
-            $output .= "✅ The <em>$pageName</em> page already exists.<br />";
-        }
-        return $output;
-    }
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
 
-    private function updatePageRapideHaut(string $output): string
-    {
-        $pageManager = $this->getService(PageManager::class);
-        // if the page doesn't exist, error
-        $pageRapideHaut = $pageManager->getOne('PageRapideHaut');
-        if (empty($pageRapideHaut)) {
-            $output .= "! The <em>$pageName</em> page does not exist.<br />";
-        } else {
-            if (!strstr($pageRapideHaut['body'], 'AdminWikis')) {
-                $content = $this->loadFileContent('pages', 'PageRapideHaut');
-                $output .= "ℹ️ Adding menu item in <em>PageRapideHaut</em> for the farm<br />";
-                $pageManager->save('PageRapideHaut', str_replace('{{end elem="buttondropdown"}}', "$content\n{{end elem=\"buttondropdown\"}}", $pageRapideHaut['body']), "", true);
-                $output .= '✅ Done !<br />';
-            } else {
-                $output .= "! The menu items in <em>PageRapideHaut</em> already exist.<br />";
-            }
+        $messages = [];
+        $updateHandlerService->createWikiModelsFolder($messages);
+        $updateHandlerService->installListeOuiNon($messages);
+        $updateHandlerService->installFarmForm($messages);
+
+        if (empty($pageManager->getOne('AdminWikis'))) {
+            $updateHandlerService->updatePageRapideHaut($messages);
         }
-        return $output;
+        $updateHandlerService->updatePage('AdminWikis', $messages);
+        $updateHandlerService->updatePage('AjouterWiki', $messages, ['{FarmFormId}' => $this->params->get('bazar_farm_id')]);
+        // $updateHandlerService->updatePage('ContactWikis', $messages);
+        $updateHandlerService->updatePage('ModelesWiki', $messages);
+
+        if (!empty($messages)) {
+            $message = implode(
+                '<br/>',
+                array_map(
+                    function ($lines) {
+                        return implode('<br/>', $lines);
+                    },
+                    array_column($messages, 'lines')
+                )
+            );
+            $output = <<<HTML
+            <strong>Extension Ferme</strong><br/>
+            $message<br/>
+            <hr/>
+            HTML;
+
+            // set output
+            $this->output = str_replace(
+                '<!-- end handler /update -->',
+                $output . '<!-- end handler /update -->',
+                $this->output
+            );
+        }
     }
 }

--- a/migrations/20240524000000_CreateWikiModelsFolder.php
+++ b/migrations/20240524000000_CreateWikiModelsFolder.php
@@ -1,0 +1,26 @@
+<?php
+
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class CreateWikiModelsFolder extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $messages = [];
+        $updateHandlerService->createWikiModelsFolder($messages);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_InstallFarmForm.php
+++ b/migrations/20240524000000_InstallFarmForm.php
@@ -1,0 +1,26 @@
+<?php
+
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class InstallFarmForm extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $messages = [];
+        $updateHandlerService->installFarmForm($messages);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_InstallListeOuiNon.php
+++ b/migrations/20240524000000_InstallListeOuiNon.php
@@ -1,0 +1,26 @@
+<?php
+
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class InstallListeOuiNon extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $messages = [];
+        $updateHandlerService->installListeOuiNon($messages);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_UpdatePageAdminWikis.php
+++ b/migrations/20240524000000_UpdatePageAdminWikis.php
@@ -1,0 +1,26 @@
+<?php
+
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class UpdatePageAdminWikis extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $messages = [];
+        $updateHandlerService->updatePage('AdminWikis', $messages);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_UpdatePageAjouterWiki.php
+++ b/migrations/20240524000000_UpdatePageAjouterWiki.php
@@ -1,0 +1,28 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class UpdatePageAjouterWiki extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $params = $this->getService(ParameterBagInterface::class);
+        $messages = [];
+        $updateHandlerService->updatePage('AjouterWiki', $messages, ['{FarmFormId}' => $params->get('bazar_farm_id')]);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_UpdatePageModelesWiki.php
+++ b/migrations/20240524000000_UpdatePageModelesWiki.php
@@ -1,0 +1,26 @@
+<?php
+
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class UpdatePageModelesWiki extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $messages = [];
+        $updateHandlerService->updatePage('ModelesWiki', $messages);
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/migrations/20240524000000_UpdatePageRapideHaut.php
+++ b/migrations/20240524000000_UpdatePageRapideHaut.php
@@ -1,0 +1,30 @@
+<?php
+
+use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\YesWikiMigration;
+use YesWiki\Ferme\Service\UpdateHandlerService;
+
+class UpdatePageRapideHaut extends YesWikiMigration
+{
+    public function run()
+    {
+        $updateHandlerService = $this->getService(UpdateHandlerService::class);
+        $pageManager = $this->getService(PageManager::class);
+        $messages = [];
+        if (empty($pageManager->getOne('AdminWikis'))) {
+            $updateHandlerService->updatePageRapideHaut($messages);
+        }
+        $errors = array_column(
+            array_filter(
+                $messages,
+                function ($message) {
+                    return $message['status'] != 'ok';
+                }
+            ),
+            'text'
+        );
+        if (!empty($errors)) {
+            throw new Exception('Error Processing ' . implode('|', $errors));
+        }
+    }
+}

--- a/services/UpdateHandlerService.php
+++ b/services/UpdateHandlerService.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace YesWiki\Ferme\Service;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Bazar\Service\FormManager;
+use YesWiki\Core\Service\AclService;
+use YesWiki\Core\Service\DbService;
+use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\Service\TripleStore;
+use YesWiki\Wiki;
+
+class UpdateHandlerService
+{
+    public const PATHS = [
+        'lists' => [
+            'ListeOuiNon' => 'tools/ferme/setup/lists/ListeOuiNon.json',
+        ],
+        'forms' => [
+            'Farm description' => 'tools/ferme/setup/forms/Form - Farm.json',
+            'Farm template' => 'tools/ferme/setup/forms/Form - Farm - template.txt',
+        ],
+        'pages' => [
+            'AdminWikis' => 'tools/ferme/setup/pages/AdminWikis.txt',
+            'AjouterWiki' => 'tools/ferme/setup/pages/AjouterWiki.txt',
+            // 'ContactWikis' => 'tools/ferme/setup/pages/ContactWikis.txt',
+            'ModelesWiki' => 'tools/ferme/setup/pages/ModelesWiki.txt',
+            'PageRapideHaut' => 'tools/ferme/setup/pages/PageRapideHaut.txt',
+        ],
+    ];
+
+    protected $aclService;
+    protected $dbService;
+    protected $entryManager;
+    protected $formManager;
+    protected $pageManager;
+    protected $params;
+    protected $tripleStore;
+    protected $wiki;
+
+    public function __construct(
+        AclService $aclService,
+        DbService $dbService,
+        EntryManager $entryManager,
+        FormManager $formManager,
+        PageManager $pageManager,
+        ParameterBagInterface $params,
+        TripleStore $tripleStore,
+        Wiki $wiki
+    ) {
+        $this->aclService = $aclService;
+        $this->dbService = $dbService;
+        $this->entryManager = $entryManager;
+        $this->formManager = $formManager;
+        $this->pageManager = $pageManager;
+        $this->params = $params;
+        $this->tripleStore = $tripleStore;
+        $this->wiki = $wiki;
+    }
+
+    public function createWikiModelsFolder(array &$messages)
+    {
+        $customWikiModelDir = 'custom/wiki-models/';
+        $lines = ["ℹ️ Creating the folder <em>$customWikiModelDir</em> for the wiki models"];
+        $text = "Creating the folder \"$customWikiModelDir\" for the wiki models";
+        $status = _t('AU_ERROR');
+        // Structure de répertoire désirée
+        if (!is_dir($customWikiModelDir)) {
+            if (mkdir($customWikiModelDir, 0777, true)) {
+                $lines[] = '✅Done !';
+                $status = _t('AU_OK');
+            } else {
+                $lines[] = "! Not possible to create folder !";
+                $text .= "! Not possible to create folder !";
+            }
+        } else {
+            $lines[] = "✅ The folder <em>$customWikiModelDir</em> for the wiki models already exists.";
+            $status = _t('AU_OK');
+        }
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    public function installListeOuiNon(array &$messages)
+    {
+        $lines = ['ℹ️ Adding the <em>Oui Non</em> list'];
+        $text = 'Adding the "Oui Non" list';
+        $status = _t('AU_ERROR');
+        // if the OuiNon Lms list doesn't exist, create it
+        if (!$this->pageManager->getOne('ListeOuiNon')) {
+            // save the page with the list value
+            $this->pageManager->save('ListeOuiNon', $this->loadFileContent('lists', 'ListeOuiNon'));
+            // in case, there is already some triples for 'ListOuinonLms', delete them
+            $this->tripleStore->delete('ListeOuiNon', 'http://outils-reseaux.org/_vocabulary/type', null);
+            // create the triple to specify this page is a list
+            $this->tripleStore->create('ListeOuiNon', 'http://outils-reseaux.org/_vocabulary/type', 'liste', '', '');
+            $lines[] = '✅ Done !';
+        } else {
+            $lines[] = '✅ The <em>Oui Non</em> list already exists.';
+        }
+        $status = _t('AU_OK');
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    public function installFarmForm(array &$messages)
+    {
+        // test if the FARM form exists, if not, install it
+        $formDescription = json_decode($this->loadFileContent('forms', 'Farm description'), true);
+        $formTemplate = $this->loadFileContent('forms', 'Farm template');
+        $formTemplate = str_replace('{UtilisationDonnees}', $this->wiki->Href('', 'UtilisationDonnees'), $formTemplate);
+        $formTemplate = str_replace('{Contact}', $this->wiki->Href('', 'Contact'), $formTemplate);
+        if (empty($formTemplate)) {
+            $messages[] = [
+                'lines' => ["! not possible to add <em>farm</em> form !"],
+                'text' => '! not possible to add "farm" form !',
+                'status' => _t('AU_ERROR')
+            ];
+        } else {
+            $this->checkAndAddForm(
+                $messages,
+                $this->params->get('bazar_farm_id'),
+                $formDescription["FARM_FORM_NOM"],
+                $formDescription["FARM_FORM_DESCRIPTION"],
+                $formTemplate
+            );
+        }
+    }
+
+    protected function checkAndAddForm(
+        array &$messages,
+        $formId,
+        $formName,
+        $formDescription,
+        $formTemplate
+    ) {
+        $lines = ["ℹ️ Adding <em>{$formName}</em> form into <em>{$this->dbService->prefixTable('nature')}</em> table."];
+        $text = "Adding \"{$formName}\" form into \"{$this->dbService->prefixTable('nature')}\" table.";
+        $status = _t('AU_ERROR');
+        $form = $this->formManager->getOne($formId);
+        if (!empty($form)) {
+            $lines[] = "✅ The <em>{$formName}</em> form already exists in the <em>{$this->dbService->prefixTable('nature')}</em> table.";
+            $status = _t('AU_OK');
+        } else {
+            $this->formManager->create([
+                'bn_id_nature' => $formId,
+                'bn_label_nature' => $formName,
+                'bn_template' => $formTemplate,
+                'bn_description' => $formDescription,
+                'bn_sem_context' => $formDescription,
+                'bn_sem_type' => '',
+                'bn_sem_use_template' => '1',
+                'bn_condition' => '',
+            ]);
+
+            $lines[] = '✅ Done !';
+            $status = _t('AU_OK');
+        }
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    public function removeBfDossierField(array &$messages)
+    {
+        $lines = ["ℹ️ Removing bf_dossier fields from bazar entries in {$this->dbService->prefixTable('pages')} table."];
+        $text = "Removing bf_dossier fields from bazar entries in {$this->dbService->prefixTable('pages')} table.";
+        $status = _t('AU_ERROR');
+        // remove bf_dossier fields
+        if (method_exists(EntryManager::class, 'removeAttributes')) {
+            if ($this->entryManager->removeAttributes([], ['bf_dossier-wiki_wikiname','bf_dossier-wiki_email','bf_dossier-wiki_password'], true)) {
+                $lines[] = '✅ Done !';
+            } else {
+                $lines[] = "✅ The table {$this->dbService->prefixTable('pages')} is already free of bf_dossier fields in bazar entries !";
+            }
+            $status = _t('AU_OK');
+        } else {
+            $lines[] = "! Not possible to remove bf_dossier fields from bazar entries in {$this->dbService->prefixTable('pages')} table.";
+        }
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    /**
+     * @param array $messages
+     */
+    public function updatePageRapideHaut(array &$messages)
+    {
+        $lines = ['ℹ️ Updating page "PageRapideHaut"'];
+        $text = 'Updating page "PageRapideHaut"';
+        $status = _t('AU_ERROR');
+        $pageRapideHaut = $this->pageManager->getOne('PageRapideHaut');
+        if (empty($pageRapideHaut)) {
+            $lines[] = "! The <em>$pageName</em> page does not exist.";
+            $text .= ' The page does not exist !';
+        } elseif (strstr($pageRapideHaut['body'], 'AdminWikis')) {
+            $lines[] = "! The menu items in <em>PageRapideHaut</em> already exist.";
+            $status = _t('AU_OK');
+        } else {
+            $content = $this->loadFileContent('pages', 'PageRapideHaut');
+            $lines[] = "ℹ️ Adding menu item in <em>PageRapideHaut</em> for the farm";
+            $this->pageManager->save('PageRapideHaut', str_replace('{{end elem="buttondropdown"}}', "$content\n{{end elem=\"buttondropdown\"}}", $pageRapideHaut['body']), "", true);
+            $lines[] = '✅ Done !';
+            $status = _t('AU_OK');
+        }
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    public function updatePage(
+        string $pageName,
+        array &$messages,
+        array $replacements = []
+    ): string {
+        $lines = ["ℹ️ Adding the <em>$pageName</em> page"];
+        $text = "Adding the \"$pageName\" page";
+        $status = _t('AU_ERROR');
+        if (!empty($this->pageManager->getOne($pageName))) {
+            $lines[] = "✅ The <em>$pageName</em> page already exists.";
+            $status = _t('AU_OK');
+        } else {
+            $content = $this->loadFileContent('pages', $pageName);
+            if (!empty($replacements)) {
+                $content = str_replace(array_keys($replacements), array_values($replacements), $content);
+            }
+            $this->aclService->delete($pageName); // to clear acl cache
+            $this->aclService->save($pageName, 'read', '@admins');
+            $this->aclService->save($pageName, 'write', '@admins');
+            $this->pageManager->save($pageName, $content, "", true);
+            $lines[] = '✅ Done !';
+            $status = _t('AU_OK');
+        }
+        $messages[] = compact(['lines','text','status']);
+    }
+
+    protected function loadFileContent(string $type, string $name): string
+    {
+        if (!isset(self::PATHS[$type]) || !isset(self::PATHS[$type][$name])) {
+            return '';
+        }
+        $path = self::PATHS[$type][$name];
+        return file_get_contents($path);
+    }
+}

--- a/services/UpdateHandlerService.php
+++ b/services/UpdateHandlerService.php
@@ -206,7 +206,7 @@ class UpdateHandlerService
         string $pageName,
         array &$messages,
         array $replacements = []
-    ): string {
+    ) {
         $lines = ["ℹ️ Adding the <em>$pageName</em> page"];
         $text = "Adding the \"$pageName\" page";
         $status = _t('AU_ERROR');


### PR DESCRIPTION
**Objectif**
Permettre la compatibilité de cette extension avec les nouveautés du système de mise à jour de la prochaine version de doryphore

**ce que ça fait**
 - ajoute un test de version pour utiliser `UpdateHandler__.php` uniquement pour les versions jusqu'à `4.4.4`
 - ajoute un service `UpdateHandlerService.php` qui permet de mutualiser le code pour le déploiement des correctifs
 - ajoute des `migrations` pour modification  dans le nouveau format de mise à jour

**tag**:
 - une fois cette PR intégrée, il serait bon de créer un nouveau tag pour déployer le correctif

**pour tester**:
 - en `doryphore 4.4.4` : handler `/update`
 - après  `doryphore 4.4.4` : lien `?GererMisesAJour&action=post_install`